### PR TITLE
 fix: 修复用户逻辑删除后 Redis 会话未同步清理问题 

### DIFF
--- a/waynboot-admin-api/src/main/java/com/wayn/admin/api/controller/system/UserController.java
+++ b/waynboot-admin-api/src/main/java/com/wayn/admin/api/controller/system/UserController.java
@@ -2,6 +2,7 @@ package com.wayn.admin.api.controller.system;
 
 import com.baomidou.mybatisplus.core.metadata.IPage;
 import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import com.wayn.admin.framework.security.service.TokenService;
 import com.wayn.admin.framework.security.util.SecurityUtils;
 import com.wayn.common.annotation.Log;
 import com.wayn.common.base.controller.BaseController;
@@ -13,6 +14,7 @@ import com.wayn.util.constant.SysConstants;
 import com.wayn.util.enums.ModuleEnum;
 import com.wayn.util.enums.OperatorEnum;
 import com.wayn.util.enums.ReturnCodeEnum;
+import com.wayn.util.enums.UserStatusEnum;
 import com.wayn.util.exception.BusinessException;
 import com.wayn.util.util.R;
 import com.wayn.util.util.excel.ExcelUtil;
@@ -43,6 +45,8 @@ public class UserController extends BaseController {
     private IUserService iUserService;
 
     private IRoleService iRoleService;
+
+    private TokenService tokenService;
 
     /**
      * 用户列表
@@ -148,7 +152,11 @@ public class UserController extends BaseController {
     public R<Boolean> changeStatus(@RequestBody User user) {
         iUserService.checkUserAllowed(user);
         user.setUpdateBy(SecurityUtils.getUsername());
-        return R.result(iUserService.updateById(user));
+        boolean updated = iUserService.updateById(user);
+        if (updated && Objects.equals(UserStatusEnum.DISABLE.getCode(), user.getUserStatus()) && user.getUserId() != null) {
+            tokenService.clearUserTokens(user.getUserId());
+        }
+        return R.result(updated);
     }
 
     /**
@@ -160,7 +168,20 @@ public class UserController extends BaseController {
     @PreAuthorize("@ss.hasPermi('system:user:delete')")
     @DeleteMapping("/{userIds}")
     public R<Boolean> deleteUser(@PathVariable List<Long> userIds) {
-        return R.result(iUserService.removeByIds(userIds));
+        boolean removed = iUserService.removeByIds(userIds);
+        if (removed) {
+            tokenService.clearUserTokens(userIds);
+        } else {
+            // 兼容逻辑删除场景：若当前用户已不存在（常见于已逻辑删除后重复删除），仍需补清会话。
+            List<Long> notExistsUserIds = userIds.stream()
+                    .filter(Objects::nonNull)
+                    .filter(userId -> iUserService.getById(userId) == null)
+                    .toList();
+            if (!notExistsUserIds.isEmpty()) {
+                tokenService.clearUserTokens(notExistsUserIds);
+            }
+        }
+        return R.result(removed);
     }
 
     /**

--- a/waynboot-admin-api/src/main/java/com/wayn/admin/framework/security/handle/LogoutSuccessHandlerImpl.java
+++ b/waynboot-admin-api/src/main/java/com/wayn/admin/framework/security/handle/LogoutSuccessHandlerImpl.java
@@ -29,7 +29,7 @@ public class LogoutSuccessHandlerImpl implements LogoutSuccessHandler {
     public void onLogoutSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
         LoginUserDetail loginUser = tokenService.getLoginUser(request);
         if (Objects.nonNull(loginUser)) {
-            // 删除用户缓存记录
+            // 删除用户缓存记录，并同步清理 user->token 索引。
             tokenService.delLoginUser(loginUser.getToken());
         }
         // 设置状态码

--- a/waynboot-admin-api/src/main/java/com/wayn/admin/framework/security/service/TokenService.java
+++ b/waynboot-admin-api/src/main/java/com/wayn/admin/framework/security/service/TokenService.java
@@ -9,13 +9,20 @@ import com.wayn.util.constant.SysConstants;
 import com.wayn.util.util.jwt.JwtUtil;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 @Component
+@Slf4j
 @AllArgsConstructor
 public class TokenService {
 
@@ -50,6 +57,10 @@ public class TokenService {
     public void delLoginUser(String token) {
         if (StringUtils.isNotEmpty(token)) {
             String userKey = getTokenKey(token);
+            LoginUserDetail loginUser = redisCache.getCacheObject(userKey);
+            if (loginUser != null && loginUser.getUser() != null && loginUser.getUser().getUserId() != null) {
+                unbindUserToken(loginUser.getUser().getUserId(), token);
+            }
             redisCache.deleteObject(userKey);
         }
     }
@@ -60,6 +71,9 @@ public class TokenService {
         // 根据uuid将loginUser缓存
         String userKey = CacheConstants.LOGIN_TOKEN_KEY + loginUser.getToken();
         redisCache.setCacheObject(userKey, loginUser, config.getExpireTime(), TimeUnit.MINUTES);
+        if (loginUser.getUser() != null && loginUser.getUser().getUserId() != null) {
+            bindUserToken(loginUser.getUser().getUserId(), loginUser.getToken());
+        }
     }
 
     public void verifyToken(LoginUserDetail loginUser) {
@@ -94,4 +108,165 @@ public class TokenService {
         return CacheConstants.LOGIN_TOKEN_KEY + sign;
     }
 
+    /**
+     * 绑定用户和 token 的索引关系，支持多端会话并发。
+     *
+     * @param userId 用户 ID
+     * @param tokenSign token 随机签名
+     */
+    public void bindUserToken(Long userId, String tokenSign) {
+        if (userId == null || StringUtils.isBlank(tokenSign)) {
+            return;
+        }
+        try {
+            String userTokenKey = getUserTokenSetKey(userId);
+            redisCache.addCacheSetValue(userTokenKey, tokenSign);
+            // 索引 key 续期需与 token TTL 同步，避免索引先过期导致无法精准踢下线。
+            redisCache.expire(userTokenKey, config.getExpireTime(), TimeUnit.MINUTES);
+        } catch (Exception e) {
+            // 先打日志，后续可接入本地消息补偿任务做索引回补。
+            log.error("绑定用户会话索引失败, userId={}, tokenSign={}", userId, tokenSign, e);
+        }
+    }
+
+    /**
+     * 解绑用户和 token 的索引关系。
+     *
+     * @param userId 用户 ID
+     * @param tokenSign token 随机签名
+     */
+    public void unbindUserToken(Long userId, String tokenSign) {
+        if (userId == null || StringUtils.isBlank(tokenSign)) {
+            return;
+        }
+        try {
+            redisCache.removeCacheSetValue(getUserTokenSetKey(userId), tokenSign);
+        } catch (Exception e) {
+            log.warn("解绑用户会话索引失败, userId={}, tokenSign={}", userId, tokenSign, e);
+        }
+    }
+
+    /**
+     * 清理指定用户的全部会话 token。
+     *
+     * @param userId 用户 ID
+     */
+    public void clearUserTokens(Long userId) {
+        if (userId == null) {
+            return;
+        }
+        String userTokenSetKey = getUserTokenSetKey(userId);
+        Set<String> tokenSigns = redisCache.getCacheSet(userTokenSetKey);
+        List<String> tokenKeys = buildTokenKeysFromSigns(tokenSigns);
+        if (tokenKeys.isEmpty()) {
+            // 兼容历史数据：当用户索引缺失时，兜底扫描主 token key 反查 userId，避免漏删会话。
+            tokenKeys = findTokenKeysByUserId(userId);
+        }
+        boolean deletedTokenMainKeys = true;
+        if (!tokenKeys.isEmpty()) {
+            try {
+                redisCache.deleteObject(tokenKeys);
+            } catch (Exception e) {
+                // 主 token key 删除失败时保留索引，方便后续重试精准清理，避免出现“索引丢失但 token 仍存活”。
+                deletedTokenMainKeys = false;
+                log.warn("批量删除用户会话 token 主键失败, userId={}, tokenCount={}", userId, tokenKeys.size(), e);
+            }
+        }
+        if (deletedTokenMainKeys) {
+            redisCache.deleteObject(userTokenSetKey);
+        } else {
+            log.warn("跳过删除用户会话索引, userId={}, reason=token-main-key-delete-failed", userId);
+        }
+    }
+
+    /**
+     * 批量清理用户会话 token。
+     *
+     * @param userIds 用户 ID 列表
+     */
+    public void clearUserTokens(List<Long> userIds) {
+        if (userIds == null || userIds.isEmpty()) {
+            return;
+        }
+        for (Long userId : userIds) {
+            clearUserTokens(userId);
+        }
+    }
+
+    /**
+     * 回填用户 token 索引，支持平滑迁移阶段幂等重建。
+     * 读取旧 token 主键，按缓存内 userId 重建 user->token 集合。
+     *
+     * @return 回填的 token 数量
+     */
+    public int rebuildUserTokenIndex() {
+        Set<String> tokenKeys = redisCache.scan(CacheConstants.LOGIN_TOKEN_KEY + "*");
+        if (tokenKeys == null || tokenKeys.isEmpty()) {
+            return 0;
+        }
+        int rebuilt = 0;
+        for (String tokenKey : tokenKeys) {
+            try {
+                LoginUserDetail loginUser = redisCache.getCacheObject(tokenKey);
+                if (loginUser == null || loginUser.getUser() == null || loginUser.getUser().getUserId() == null) {
+                    continue;
+                }
+                String tokenSign = tokenKey.substring(CacheConstants.LOGIN_TOKEN_KEY.length());
+                bindUserToken(loginUser.getUser().getUserId(), tokenSign);
+                rebuilt++;
+            } catch (Exception e) {
+                log.warn("回填用户会话索引失败, tokenKey={}", tokenKey, e);
+            }
+        }
+        return rebuilt;
+    }
+
+    private String getUserTokenSetKey(Long userId) {
+        return CacheConstants.USER_LOGIN_TOKEN_KEY_PREFIX + userId;
+    }
+
+    /**
+     * 将 tokenSign 集合转换为 Redis 主 token key 列表。
+     *
+     * @param tokenSigns tokenSign 集合
+     * @return Redis 主 token key 列表
+     */
+    private List<String> buildTokenKeysFromSigns(Set<String> tokenSigns) {
+        if (tokenSigns == null || tokenSigns.isEmpty()) {
+            return Collections.emptyList();
+        }
+        List<String> tokenKeys = new ArrayList<>(tokenSigns.size());
+        for (String tokenSign : tokenSigns) {
+            tokenKeys.add(getTokenKey(tokenSign));
+        }
+        return tokenKeys;
+    }
+
+    /**
+     * 兜底扫描登录主 key，根据缓存中的 userId 精准筛选出当前用户会话 key。
+     *
+     * @param userId 用户 ID
+     * @return 命中的 Redis 主 token key 列表
+     */
+    private List<String> findTokenKeysByUserId(Long userId) {
+        Set<String> allTokenKeys = redisCache.scan(CacheConstants.LOGIN_TOKEN_KEY + "*");
+        if (allTokenKeys == null || allTokenKeys.isEmpty()) {
+            return Collections.emptyList();
+        }
+        List<String> matchedTokenKeys = new ArrayList<>();
+        for (String tokenKey : allTokenKeys) {
+            try {
+                LoginUserDetail loginUser = redisCache.getCacheObject(tokenKey);
+                if (loginUser == null || loginUser.getUser() == null) {
+                    continue;
+                }
+                if (Objects.equals(userId, loginUser.getUser().getUserId())) {
+                    matchedTokenKeys.add(tokenKey);
+                }
+            } catch (Exception e) {
+                log.warn("扫描用户会话 token 失败, userId={}, tokenKey={}", userId, tokenKey, e);
+            }
+        }
+        return matchedTokenKeys;
+    }
 }

--- a/waynboot-admin-api/src/test/java/com/wayn/admin/api/controller/system/UserControllerTest.java
+++ b/waynboot-admin-api/src/test/java/com/wayn/admin/api/controller/system/UserControllerTest.java
@@ -1,0 +1,115 @@
+package com.wayn.admin.api.controller.system;
+
+import com.wayn.admin.framework.security.service.TokenService;
+import com.wayn.admin.framework.security.model.LoginUserDetail;
+import com.wayn.common.core.entity.system.User;
+import com.wayn.common.core.service.system.IRoleService;
+import com.wayn.common.core.service.system.IUserService;
+import com.wayn.util.enums.UserStatusEnum;
+import com.wayn.util.util.R;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class UserControllerTest {
+
+    @Mock
+    private IUserService userService;
+    @Mock
+    private IRoleService roleService;
+    @Mock
+    private TokenService tokenService;
+
+    @Test
+    void deleteUserShouldClearTokensAfterDatabaseRemoval() {
+        UserController controller = new UserController(userService, roleService, tokenService);
+        List<Long> userIds = List.of(101L, 102L);
+        when(userService.removeByIds(userIds)).thenReturn(true);
+
+        R<Boolean> result = controller.deleteUser(userIds);
+
+        assertThat(result.getCode()).isEqualTo(200);
+        verify(tokenService).clearUserTokens(userIds);
+    }
+
+    @Test
+    void deleteUserShouldClearTokensForAlreadyDeletedUsersWhenDatabaseRemovalFailed() {
+        UserController controller = new UserController(userService, roleService, tokenService);
+        List<Long> userIds = List.of(201L);
+        when(userService.removeByIds(userIds)).thenReturn(false);
+        when(userService.getById(201L)).thenReturn(null);
+
+        R<Boolean> result = controller.deleteUser(userIds);
+
+        assertThat(result.getCode()).isEqualTo(500);
+        verify(tokenService).clearUserTokens(userIds);
+    }
+
+    @Test
+    void deleteUserShouldNotClearTokensWhenDatabaseRemovalFailedAndUserStillExists() {
+        UserController controller = new UserController(userService, roleService, tokenService);
+        List<Long> userIds = List.of(202L);
+        User user = new User();
+        user.setUserId(202L);
+        when(userService.removeByIds(userIds)).thenReturn(false);
+        when(userService.getById(202L)).thenReturn(user);
+
+        R<Boolean> result = controller.deleteUser(userIds);
+
+        assertThat(result.getCode()).isEqualTo(500);
+        verify(tokenService, never()).clearUserTokens(userIds);
+    }
+
+    @Test
+    void changeStatusShouldClearTokensWhenUserIsDisabled() {
+        UserController controller = new UserController(userService, roleService, tokenService);
+        User user = new User();
+        user.setUserId(301L);
+        user.setUserStatus(UserStatusEnum.DISABLE.getCode());
+        when(userService.updateById(user)).thenReturn(true);
+        mockLoginContext("admin");
+
+        R<Boolean> result = controller.changeStatus(user);
+
+        assertThat(result.getCode()).isEqualTo(200);
+        verify(tokenService).clearUserTokens(301L);
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void changeStatusShouldNotClearTokensWhenUserIsEnabled() {
+        UserController controller = new UserController(userService, roleService, tokenService);
+        User user = new User();
+        user.setUserId(401L);
+        user.setUserStatus(UserStatusEnum.OK.getCode());
+        when(userService.updateById(user)).thenReturn(true);
+        mockLoginContext("admin");
+
+        R<Boolean> result = controller.changeStatus(user);
+
+        assertThat(result.getCode()).isEqualTo(200);
+        verify(tokenService, never()).clearUserTokens(401L);
+        SecurityContextHolder.clearContext();
+    }
+
+    private void mockLoginContext(String username) {
+        User loginUser = new User();
+        loginUser.setUserId(1L);
+        loginUser.setUserName(username);
+        LoginUserDetail loginUserDetail = new LoginUserDetail(loginUser);
+        UsernamePasswordAuthenticationToken authenticationToken =
+                new UsernamePasswordAuthenticationToken(loginUserDetail, null, null);
+        SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+    }
+}

--- a/waynboot-admin-api/src/test/java/com/wayn/admin/framework/security/service/TokenServiceTest.java
+++ b/waynboot-admin-api/src/test/java/com/wayn/admin/framework/security/service/TokenServiceTest.java
@@ -1,0 +1,141 @@
+package com.wayn.admin.framework.security.service;
+
+import com.wayn.admin.framework.security.model.LoginUserDetail;
+import com.wayn.common.config.TokenConfig;
+import com.wayn.common.core.entity.system.User;
+import com.wayn.data.redis.constant.CacheConstants;
+import com.wayn.data.redis.manager.RedisCache;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TokenServiceTest {
+
+    @Mock
+    private RedisCache redisCache;
+
+    private TokenService tokenService;
+
+    @BeforeEach
+    void setUp() {
+        TokenConfig config = new TokenConfig();
+        config.setExpireTime(120);
+        config.setHeader("Authorization");
+        config.setSecret("test-secret");
+        tokenService = new TokenService(redisCache, config);
+    }
+
+    @Test
+    void refreshTokenShouldWriteTokenAndSyncUserTokenIndexTtl() {
+        LoginUserDetail loginUser = buildLoginUser(1001L, "abc-token-sign");
+
+        tokenService.refreshToken(loginUser);
+
+        verify(redisCache).setCacheObject(CacheConstants.LOGIN_TOKEN_KEY + "abc-token-sign", loginUser, 120, TimeUnit.MINUTES);
+        verify(redisCache).addCacheSetValue(CacheConstants.USER_LOGIN_TOKEN_KEY_PREFIX + 1001L, "abc-token-sign");
+        verify(redisCache).expire(CacheConstants.USER_LOGIN_TOKEN_KEY_PREFIX + 1001L, 120, TimeUnit.MINUTES);
+        assertThat(loginUser.getExpireTime()).isGreaterThan(loginUser.getLoginTime());
+    }
+
+    @Test
+    void delLoginUserShouldDeleteTokenAndUnbindUserTokenIndex() {
+        LoginUserDetail loginUser = buildLoginUser(1002L, "token-2");
+        when(redisCache.getCacheObject(CacheConstants.LOGIN_TOKEN_KEY + "token-2")).thenReturn(loginUser);
+
+        tokenService.delLoginUser("token-2");
+
+        verify(redisCache).removeCacheSetValue(CacheConstants.USER_LOGIN_TOKEN_KEY_PREFIX + 1002L, "token-2");
+        verify(redisCache).deleteObject(CacheConstants.LOGIN_TOKEN_KEY + "token-2");
+    }
+
+    @Test
+    void clearUserTokensShouldDeleteAllTokenKeysAndIndexKey() {
+        when(redisCache.getCacheSet(CacheConstants.USER_LOGIN_TOKEN_KEY_PREFIX + 1003L))
+                .thenReturn(Set.of("s1", "s2"));
+
+        tokenService.clearUserTokens(1003L);
+
+        ArgumentCaptor<List> tokenKeysCaptor = ArgumentCaptor.forClass(List.class);
+        verify(redisCache).deleteObject(tokenKeysCaptor.capture());
+        assertThat(tokenKeysCaptor.getValue())
+                .containsExactlyInAnyOrder(CacheConstants.LOGIN_TOKEN_KEY + "s1", CacheConstants.LOGIN_TOKEN_KEY + "s2");
+        verify(redisCache).deleteObject(CacheConstants.USER_LOGIN_TOKEN_KEY_PREFIX + 1003L);
+    }
+
+    @Test
+    void clearUserTokensForListShouldClearEachUser() {
+        when(redisCache.getCacheSet(anyString())).thenReturn(Set.of());
+
+        tokenService.clearUserTokens(List.of(2001L, 2002L));
+
+        verify(redisCache).getCacheSet(CacheConstants.USER_LOGIN_TOKEN_KEY_PREFIX + 2001L);
+        verify(redisCache).getCacheSet(CacheConstants.USER_LOGIN_TOKEN_KEY_PREFIX + 2002L);
+        verify(redisCache).deleteObject(CacheConstants.USER_LOGIN_TOKEN_KEY_PREFIX + 2001L);
+        verify(redisCache).deleteObject(CacheConstants.USER_LOGIN_TOKEN_KEY_PREFIX + 2002L);
+    }
+
+    @Test
+    void clearUserTokensShouldFallbackScanWhenIndexMissing() {
+        String tokenKey = CacheConstants.LOGIN_TOKEN_KEY + "legacy-sign";
+        when(redisCache.getCacheSet(CacheConstants.USER_LOGIN_TOKEN_KEY_PREFIX + 3003L)).thenReturn(Set.of());
+        when(redisCache.scan(CacheConstants.LOGIN_TOKEN_KEY + "*")).thenReturn(Set.of(tokenKey));
+        when(redisCache.getCacheObject(tokenKey)).thenReturn(buildLoginUser(3003L, "legacy-sign"));
+
+        tokenService.clearUserTokens(3003L);
+
+        verify(redisCache).deleteObject(List.of(tokenKey));
+        verify(redisCache).deleteObject(CacheConstants.USER_LOGIN_TOKEN_KEY_PREFIX + 3003L);
+    }
+
+    @Test
+    void clearUserTokensShouldKeepIndexWhenDeleteMainKeysFailed() {
+        when(redisCache.getCacheSet(CacheConstants.USER_LOGIN_TOKEN_KEY_PREFIX + 3004L)).thenReturn(Set.of("s1"));
+        doThrow(new RuntimeException("redis down")).when(redisCache).deleteObject(anyList());
+
+        tokenService.clearUserTokens(3004L);
+
+        verify(redisCache, never()).deleteObject(CacheConstants.USER_LOGIN_TOKEN_KEY_PREFIX + 3004L);
+    }
+
+    @Test
+    void rebuildUserTokenIndexShouldSkipInvalidRecordsAndBeIdempotentSafe() {
+        String key1 = CacheConstants.LOGIN_TOKEN_KEY + "sign-1";
+        String key2 = CacheConstants.LOGIN_TOKEN_KEY + "sign-2";
+        when(redisCache.scan(CacheConstants.LOGIN_TOKEN_KEY + "*")).thenReturn(Set.of(key1, key2));
+        when(redisCache.getCacheObject(key1)).thenReturn(buildLoginUser(3001L, "sign-1"));
+        when(redisCache.getCacheObject(key2)).thenReturn(null);
+
+        int rebuilt = tokenService.rebuildUserTokenIndex();
+
+        assertThat(rebuilt).isEqualTo(1);
+        verify(redisCache).addCacheSetValue(CacheConstants.USER_LOGIN_TOKEN_KEY_PREFIX + 3001L, "sign-1");
+        verify(redisCache).expire(CacheConstants.USER_LOGIN_TOKEN_KEY_PREFIX + 3001L, 120, TimeUnit.MINUTES);
+        verify(redisCache, never()).addCacheSetValue(CacheConstants.USER_LOGIN_TOKEN_KEY_PREFIX + 3002L, "sign-2");
+    }
+
+    private LoginUserDetail buildLoginUser(Long userId, String tokenSign) {
+        User user = new User();
+        user.setUserId(userId);
+        user.setUserName("u-" + userId);
+        LoginUserDetail loginUser = new LoginUserDetail(user);
+        loginUser.setToken(tokenSign);
+        return loginUser;
+    }
+}

--- a/waynboot-data/waynboot-data-redis/src/main/java/com/wayn/data/redis/constant/CacheConstants.java
+++ b/waynboot-data/waynboot-data-redis/src/main/java/com/wayn/data/redis/constant/CacheConstants.java
@@ -15,6 +15,11 @@ public class CacheConstants {
      */
     public static final String LOGIN_TOKEN_KEY = CACHE_PREFIX + "login_tokens:";
 
+    /**
+     * 用户会话索引 key 前缀，key 结构：waynboot:user_login_tokens:{userId}
+     */
+    public static final String USER_LOGIN_TOKEN_KEY_PREFIX = CACHE_PREFIX + "user_login_tokens:";
+
 
     public static final String SHOP_HOME_INDEX_HASH = CACHE_PREFIX + "shop_home_index_hash";
     public static final String SHOP_HOME_INDEX_HASH_EXPIRATION_FIELD = "expire_time";

--- a/waynboot-data/waynboot-data-redis/src/main/java/com/wayn/data/redis/manager/RedisCache.java
+++ b/waynboot-data/waynboot-data-redis/src/main/java/com/wayn/data/redis/manager/RedisCache.java
@@ -271,6 +271,32 @@ public class RedisCache {
     }
 
     /**
+     * 往 Set 中新增一个元素。
+     *
+     * @param key 缓存键
+     * @param value 元素值
+     * @param <T> 元素类型
+     * @return 新增条数
+     */
+    public <T> long addCacheSetValue(final String key, final T value) {
+        Long count = redisTemplate.opsForSet().add(key, value);
+        return count == null ? 0 : count;
+    }
+
+    /**
+     * 从 Set 中删除一个元素。
+     *
+     * @param key 缓存键
+     * @param value 元素值
+     * @param <T> 元素类型
+     * @return 删除条数
+     */
+    public <T> long removeCacheSetValue(final String key, final T value) {
+        Long count = redisTemplate.opsForSet().remove(key, value);
+        return count == null ? 0 : count;
+    }
+
+    /**
      * 缓存Map
      *
      * @param key


### PR DESCRIPTION
## 背景

  当前 DELETE /system/user/{userIds} 仅做数据库逻辑删除，历史情况下可能存在用户会话未被同步清理的问题，导致被删除用户旧JWT 在有效期内仍可访问系统，存在安全风险。Fixes #30 
  ## 变更内容

  1. 新增用户-会话索引能力

  - 新增 Redis Key：waynboot:user_login_tokens:{userId}（Set）
  - 登录/续期时同步维护 user->token 索引，并同步 TTL

  2. 增强会话清理逻辑

  - TokenService.delLoginUser：删除主 token 的同时解绑 user-token 索引
  - TokenService.clearUserTokens：
      - 优先按 user-token 索引删除会话主键
      - 当索引缺失时，兜底扫描 waynboot:login_tokens:* 反查 userId 后删除
      - 若删除主 token 失败，保留索引以便后续重试，避免“索引丢失但 token 仍存活”

  3. 修复删除用户链路

  - UserController.deleteUser：
      - removeByIds=true：按 userIds 清理会话（原逻辑保留）
      - removeByIds=false 且用户已不存在（逻辑删除场景）：补清会话，避免漏清历史 token

  4. 禁用用户会话收敛

  - changeStatus 用户禁用后清理该用户全部会话

  ## 验证结果

  ### 自动化测试

  - 命令：mvn test（JDK 17）
  - 结果：BUILD SUCCESS（全模块通过）

  ### 定向测试

  - 命令：mvn -pl waynboot-admin-api -am -Dtest=TokenServiceTest,UserControllerTest
    -Dsurefire.failIfNoSpecifiedTests=false test

  - 结果：Tests run: 12, Failures: 0, Errors: 0

  ### 手工验证（112/113）

  1. 用户登录生成 token（Redis waynboot:login_tokens:{tokenSign} = 1）
  2. 调用逻辑删除接口 DELETE /system/user/{id} 返回 200
  3. Redis 校验：对应 login_tokens 删除（EXISTS=0），user_login_tokens:{userId} 为空
  4. 旧 JWT 调 /getInfo 返回未认证

  ## 影响范围

  - 仅涉及后台认证会话清理链路（用户删除/禁用/退出）
  - 不改变现有接口契约，不影响正常登录主流程

  ## 风险与回滚

  - 风险：极端情况下 Redis 删除异常会延迟会话清理
  - 控制：保留索引便于重试，且支持兜底扫描
  - 回滚：回滚本次变更即可恢复原行为（不影响数据库数据）
