### PR TITLE
fix: shop_goods_product seed data INSERT missing default_selected column

### DIFF
--- a/db-init/wayn_shop_20230719.sql
+++ b/db-init/wayn_shop_20230719.sql
@@ -1591,7 +1591,6 @@ CREATE TABLE `shop_goods_product`  (
   `price` decimal(10, 2) NOT NULL DEFAULT 0.00 COMMENT '商品货品价格',
   `number` int NOT NULL DEFAULT 0 COMMENT '商品货品数量',
   `locked_stock` int NOT NULL DEFAULT 0 COMMENT '冻结库存数量',
-  `default_selected` tinyint(1) NULL DEFAULT 0 COMMENT '是否默认选中（0未选中 1选中）',
   `url` varchar(125) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NULL DEFAULT NULL COMMENT '商品货品图片',
   `create_time` datetime NULL DEFAULT NULL COMMENT '创建时间',
   `update_time` datetime NULL DEFAULT NULL COMMENT '更新时间',
@@ -1842,6 +1841,8 @@ INSERT INTO `shop_goods_product` VALUES (249, 1181002, '[\"标准\"]', 11.00, 11
 INSERT INTO `shop_goods_product` VALUES (250, 1181003, '[\"标准\"]', 1.00, 1, 0, '', '2020-08-20 23:21:28', NULL, 1);
 INSERT INTO `shop_goods_product` VALUES (251, 1181004, '[\"标准\"]', 1.00, 1, 0, '', '2020-08-20 23:25:05', '2020-08-20 23:43:22', 1);
 INSERT INTO `shop_goods_product` VALUES (256, 1181012, '[\"标准\"]', 0.00, 0, 1, '', '2021-04-01 18:57:51', NULL, 1);
+
+ALTER TABLE `shop_goods_product` ADD COLUMN `default_selected` tinyint(1) NULL DEFAULT 0 COMMENT '是否默认选中（0未选中 1选中）' AFTER `locked_stock`;
 
 -- ----------------------------
 -- Table structure for shop_goods_specification


### PR DESCRIPTION
## 问题

`db-init/wayn_shop_20230719.sql` 中 `shop_goods_product` 表的 CREATE TABLE 定义了 11 列（含 `default_selected`），但 239 条 INSERT 语句只有 10 个值。

Docker 首次初始化时 MySQL 容器报错退出：

```
ERROR 1136 (21S01) at line 1606: Column count doesn't match value count at row 1
```

`docker-entrypoint-initdb.d` 机制下 SQL 执行失败会导致整个数据库初始化中断，后续表也无法创建。

## 根因

表结构迭代时新增了 `default_selected` 列，种子数据的 INSERT 未同步补全。

## 修复（2 行改动）

1. CREATE TABLE 中移除 `default_selected` 列定义
2. 在所有 INSERT 之后追加 `ALTER TABLE` 补齐该列

老数据的 `default_selected` 自然取 `DEFAULT 0`，与 INSERT 中补 `0` 完全等价。

## 验证

修复后 `docker-compose -f docker-compose-es7-rabbitmq-redis-mysql.yml up -d` 全量 SQL 初始化通过：

```
inventory_stock.sql        ✅
local_message.sql          ✅
order_status_log.sql       ✅
payment_flow.sql           ✅
wayn_shop_20230719.sql     ✅
MySQL init process done. Ready for start up.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)